### PR TITLE
feature/created_user allows POST request to be sent to create user

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::UsersController < ApplicationController
+  def create
+    user = User.new(user_params)
+    if user.save
+      render json: UserSerializer.new(user), status: :created
+    else
+      render json: ErrorSerializer.format_error(user.errors.full_messages.to_sentence, 400), status: :bad_request
+    end
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :username, :email, :password_digest)
+  end
+end

--- a/app/serializers/error_serializer.rb
+++ b/app/serializers/error_serializer.rb
@@ -1,0 +1,10 @@
+class ErrorSerializer
+  def self.format_error(error, code)
+    {
+      data: {
+      message: error,
+      status: code
+    }
+  }
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,4 @@
+class UserSerializer
+  include JSONAPI::Serializer
+  attributes :name, :username, :email, :password_digest
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -5,12 +5,12 @@
 
 # Read more: https://github.com/cyu/rack-cors
 
-# Rails.application.config.middleware.insert_before 0, Rack::Cors do
-#   allow do
-#     origins "example.com"
-#
-#     resource "*",
-#       headers: :any,
-#       methods: [:get, :post, :put, :patch, :delete, :options, :head]
-#   end
-# end
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "localhost:3000"
+
+    resource "*",
+      headers: :any,
+      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,10 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "posts#index"
+  namespace :api do
+    namespace :v1 do
+      resources :users, only: [:create, :update] do
+      end
+    end
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,7 @@ Rails.application.routes.draw do
   # root "posts#index"
   namespace :api do
     namespace :v1 do
-      resources :users, only: [:create, :update] do
+      resources :users, only: [:create] do
       end
     end
   end


### PR DESCRIPTION
### Type of Change
- [x] feature ⛲

### Description
Create a backend feature that allows HTTP POST request to have users added to the database.

### Share the reason(s) for this pull request
This pull request was done to add the route `/api/v1/users` allowing a POST request with the body:

```
{
    "name": "Matt Haefling",
    "username": "mhaefling",
    "email": "m.haefling@protonmail.com",
    "password_digest": "password123"
}
```
So that when the `users_controller` receives the request an instance of a User is created in the database.

### Related Tickets
https://github.com/mhaefling/everyday-answers-be/issues/2

### Screenshots (if applicable):
<img width="957" alt="Screenshot 2025-04-29 at 8 15 48 AM" src="https://github.com/user-attachments/assets/1e14b7a6-7aec-4926-97da-f9092d28ab7d" />

### Added Test?
- [x] No 🙅

### Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation and I have updated the documentation accordingly.
- [x] All tests (previous and new) pass 🥳
- [ ] This PR includes a Migration and I have notified the PM so they can run the migration after the PR is merged.

### How to QA this change:
1. Start the server with `rails s`
2. Using Postman, send a `POST` request to `http://localhost:3000/api/v1/users` with the user body including the following attributes:  (name, username, email, password_digest)